### PR TITLE
Draft: Refactor csr

### DIFF
--- a/doc/gateware.rst
+++ b/doc/gateware.rst
@@ -88,6 +88,9 @@ Note that Migen differs from Verilog, since all indexing is LSB-first and the
 last index is excluded. Hence ``adr[0:length]`` is equivalent to ``adr[length-1:0]``
 in generated Verilog.
 
+Some modules (the extio.py ones, for instance) output magic numbers when
+an invalid access is done.
+
 -----------------------------------
 Rules For Writing Wishbone Bus Code
 -----------------------------------
@@ -123,6 +126,8 @@ keys are names of the register shown to the programmer and
 
 are required attributes. Other attributes are ``rw``, ``direction``, that are
 explained in /doc/controller_manual.rst .
+
+``public_registers`` may be dynamically generated or static.
 
 -----------------------------
 Adding Slaves to the Main CPU
@@ -180,6 +185,12 @@ to generate code with the correct offsets.
 Note that the ``csr.json`` file casefolds the memory locations into lowercase
 but keeps CSR registers as-is.
 
+The order of calls is:
+
+1. ``pre_finalize``
+2. ``do_finalize()`` (LiteX Finalization)
+3. ``mmio_closures``
+
 ====================
 System Within a Chip
 ====================
@@ -195,8 +206,8 @@ removed.) There are three ways the main CPU interacts with the SWiC:
 
 1. Direct control. The main CPU can start and reset the SWiC CPU. It can
    also inspect the SWiC CPU's registers and program counter.
-2. Exclusive registers. Small data can be transfered in the Main -> SWiC and
-   SWiC -> Main direction using *Special Registers*. They are small registers
+2. *Peek Poke Interfaces*. Small data can be transfered in the Main -> SWiC and
+   SWiC -> Main direction. It consists of small registers (at most 32 bits)
    that can be read by both CPUs but only one CPU can write to them.  This is
    used for sending parameters to programs without having to recompile them.
 3. *Preemptive Interfaces* (PI), which connect a Wishbone slave to two or more

--- a/gateware/extio.py
+++ b/gateware/extio.py
@@ -15,41 +15,69 @@ class Waveform(LiteXModule):
         by reading from RAM. """
 
     public_registers = {
+            # go from 0 to 1 to run the waveform.
+            # If "do_loop" is 0, then it will run once and then stop.
+            # run needs to be set to 0 and then 1 again to run another
+            # waveform.
+            # If "do_loop" is 1, then the waveform will loop until
+            # "run" becomes 0, after which it will finish the waveform
+            # and stop.
+
             "run" : Register(
                 origin=0,
                 bitwidth=1,
                 rw=True,
             ),
+
+            # Current sample the waveform is on.
             "cntr": Register(
                 origin=0x4,
                 bitwidth=16,
                 rw=False,
             ),
+
+            # See "run".
             "do_loop": Register(
                 origin=0x8,
                 bitwidth= 1,
                 rw= True,
             ),
+
+            # Bit 0 is the "ready" bit. "Ready" means that "run" can be
+            # set to "1" to enable a waveform run.
+            #
+            # Bit 1 is the "finished" bit. "Finished" means that the
+            # waveform has finished an output and is waiting for "run"
+            # to be set back to 0. This only happens when "do_loop" is 0.
             "finished_or_ready": Register(
                 origin=0xC,
                 bitwidth= 2,
                 rw= False,
             ),
+
+            # Size of the waveform in memory, in words.
             "wform_width": Register(
                 origin=0x10,
                 bitwidth=16,
                 rw= True,
             ),
+
+            # Current value of the timer. See below.
             "timer": Register(
                 origin=0x14,
                 bitwidth= 16,
                 rw= False,
             ),
+
+            # Amount of cycles to wait in between outputting each sample.
             "timer_spacing": Register(
                 origin= 0x18,
                 bitwidth= 16,
                 rw= True,
             ),
+
+            # Forcibly stop the output of the waveform. The SPI bus may be
+            # in an unknown state after this.
             "force_stop" : Register (
                 origin=0x1C,
                 bitwidth=1,

--- a/gateware/soc.py
+++ b/gateware/soc.py
@@ -219,7 +219,9 @@ class UpsilonSoC(SoCCore):
 
         Attributes:
     
-        * ``mmio_closures``: A list of functions that take no argument.
+        * ``mmio_closures``: A list of functions that take one argument, the
+          CSR definition.
+
           Each function returns a string that is then put directly into
           mmio.py (the MicroPython interface).
 

--- a/gateware/soc.py
+++ b/gateware/soc.py
@@ -577,6 +577,12 @@ class UpsilonSoC(SoCCore):
         self.add_module("master_selector", master_selector)
         self.interface_list = []
 
+        def tmp(csrs):
+            origin = csrs["memories"]['master_selector']['base']
+            vals = master_selector.mmio(origin)
+            return f'master_selector = RegisterRegion({origin}, {vals})\n'
+        self.mmio_closures.append(tmp)
+
         #########################
         # Add upsilon modules to this section
         #########################
@@ -623,12 +629,12 @@ class UpsilonSoC(SoCCore):
             f()
 
         for name, pi in self.interface_list:
-            master_selector.add_register(name + "_selector", false, pi.master_select)
+            master_selector.add_register(name + "_master_selector", false, pi.master_select)
 
         # Finalize preemptive interface controller.
         master_selector.pre_finalize()
         self.add_slave_with_registers(
-            "preemptive_interface_controller",
+            "master_selector",
             master_selector.bus,
             SoCRegion(origin=None, size=master_selector.width, cached=False),
             master_selector.public_registers

--- a/gateware/soc.py
+++ b/gateware/soc.py
@@ -295,7 +295,7 @@ class UpsilonSoC(SoCCore):
 
         self.mmio_closures.append(f)
         self.pre_finalize.append(lambda : pi.pre_finalize(name + "_main_PI.json"))
-        self.interface_list.append(pi)
+        self.interface_list.append((name, pi))
         return pi
 
     def add_blockram(self, name, size):
@@ -621,6 +621,9 @@ class UpsilonSoC(SoCCore):
         # Run pre-finalize
         for f in self.pre_finalize:
             f()
+
+        for name, pi in self.interface_list:
+            master_selector.add_register(name + "_selector", false, pi.master_select)
 
         # Finalize preemptive interface controller.
         master_selector.pre_finalize()

--- a/gateware/swic.py
+++ b/gateware/swic.py
@@ -176,6 +176,13 @@ class PicoRV32(LiteXModule):
     def add_cl_params(self):
         """ Add parameter region for control loop variables. Dumps the
         region information to a JSON file `dumpname`.
+
+        cl_I: the integral constant in a PI loop.
+        cl_P: the proportional constant in a PI loop.
+        deltaT: the time to wait (in whatever units)
+        setpt: setpoint value of the loop
+        zset: current value set by the output of the loop
+        zpos: current value read by ADC
         """
 
         self.params.add_register("cl_I", "1", 32)
@@ -192,6 +199,19 @@ class PicoRV32(LiteXModule):
 
         self.params = PeekPokeInterface()
         self.param_origin = param_origin
+
+        """ register documentation:
+
+            enable: 1 to start the core, 0 to reset the core.
+            trap: 0 if running fine, and a nonzero value if a trap
+              condition occurs. Check picorv32.v for trap values.
+            debug_adr: Current address being read by the core.
+            pc: Current program counter location.
+            opcode: Opcode currently being executed.
+
+            any lowercase common name of a RV32I register can be read,
+            and will give you the contents of the register.
+        """
 
         self.params.add_register("enable", "1", 1)
         self.params.add_register("trap", "", 8)

--- a/gateware/swic.py
+++ b/gateware/swic.py
@@ -19,7 +19,7 @@ class PreemptiveInterface(LiteXModule):
     single slave. A master controls which master (or interconnect) has access
     to the slave. This is to avoid bus contention by having multiple buses.
 
-    To use this module, instantiate it. Then connect the controlling master
+    To use this module, instantiate it. Then connect the default master
     to ``self.buses[0]``. Connect the other masters to ``self.buses[1]``, etc.
     Since the buses are seperate, origins don't have to be the same, but the
     size of the region will be the same as the slave interface.
@@ -66,7 +66,7 @@ class PreemptiveInterface(LiteXModule):
 
         masters_len = len(self.buses)
         if masters_len > 1:
-            self.master_select = CSRStorage(masters_len, name='master_select', description='RW bitstring of which master interconnect to connect to')
+            self.master_select = Signal(masters_len)
 
         # FIXME: Implement PreemptiveInterfaceController module to limit proliferation
         # of JSON files

--- a/gateware/swic.py
+++ b/gateware/swic.py
@@ -60,8 +60,6 @@ class PreemptiveInterface(LiteXModule):
         return iface
 
     def pre_finalize(self, dump_name):
-        # NOTE: DUMB HACK! CSR bus logic is NOT generated when inserted at do_finalize time!
-
         if self.pre_finalize_done:
             raise Exception(self.name + ": Cannot pre-finalize twice")
         self.pre_finalize_done = True


### PR DESCRIPTION
Refactors PeekPokeInterface to use the more generic RegisterRegion, which is a region of memory-mapped 32 bit registers.

RegisterRegion is used to implement a Wishbone-bus based controller for preemptive interfaces. Each preemptive interface adds itself to a list, and at the end of pre-finalize RegisterRegion reads this list and generates a wishbone bus interface to each preemptive interface.

This is a draft, I won't be able to test this.